### PR TITLE
Solve missing audio_effects.h

### DIFF
--- a/include/sound/Kbuild
+++ b/include/sound/Kbuild
@@ -15,3 +15,4 @@ header-y += lsm_params.h
 header-y += voice_params.h
 header-y += voice_svc.h
 header-y += msmcal-hwdep.h
+header-y += audio_effects.h


### PR DESCRIPTION
See https://github.com/CyanogenMod/android_kernel_oneplus_msm8974/blob/cm-12.1/include/sound/Kbuild for an example of how this is used for another kernel.

There might be other headers missing.